### PR TITLE
implement bulk host delete endpoint

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -110,6 +110,7 @@ from awx.main.utils import (
     prefetch_page_capabilities,
     get_external_account,
     truncate_stdout,
+    get_licenser,
 )
 from awx.main.utils.filters import SmartFilter
 from awx.main.utils.named_url_graph import reset_counters
@@ -1879,7 +1880,7 @@ class HostSerializer(BaseSerializerWithVariables):
             vars_dict = parse_yaml_or_json(variables)
             vars_dict['ansible_ssh_port'] = port
             attrs['variables'] = json.dumps(vars_dict)
-        if Group.objects.filter(name=name, inventory=inventory).exists():
+        if inventory and Group.objects.filter(name=name, inventory=inventory).exists():
             raise serializers.ValidationError(_('A Group with that name already exists.'))
 
         return super(HostSerializer, self).validate(attrs)
@@ -1969,6 +1970,107 @@ class GroupSerializer(BaseSerializerWithVariables):
         if obj is not None and 'inventory' in ret and not obj.inventory:
             ret['inventory'] = None
         return ret
+
+
+class BulkHostSerializer(HostSerializer):
+    name = serializers.CharField(required=True, allow_blank=False, max_length=512)
+    instance_id = serializers.CharField(required=False, max_length=1024)
+    description = serializers.CharField(required=False)
+    enabled = serializers.BooleanField(default=True, required=False)
+    variables = serializers.CharField(allow_blank=True, required=False)
+
+    class Meta:
+        fields = (
+            'name',
+            'enabled',
+            'instance_id',
+            'description',
+            'variables',
+        )
+
+
+class BulkHostCreateSerializer(serializers.Serializer):
+    inventory = serializers.PrimaryKeyRelatedField(
+        queryset=Inventory.objects.all(), required=True, write_only=True, help_text=_('Primary Key ID of inventory to add hosts to.')
+    )
+    hosts = serializers.ListField(child=BulkHostSerializer(), allow_empty=False, max_length=1000, write_only=True, help_text=_('Hosts to be created.'))
+
+    class Meta:
+        fields = ('inventory', 'hosts')
+        read_only_fields = ()
+
+    def raise_if_cannot_add_hosts(self, attrs):
+        validation_info = get_licenser().validate()
+
+        org = attrs['inventory'].organization
+
+        if org:
+            org_active_count = Host.objects.org_active_count(org.id)
+            new_hosts = [h['name'] for h in attrs['hosts']]
+            org_net_new_host_count = Host.objects.filter(inventory__organization=org.id).exclude(name__in=new_hosts).count()
+            if org.max_hosts > 0 and org_active_count + org_net_new_host_count > org.max_hosts:
+                raise PermissionDenied(
+                    _(
+                        "You have already reached the maximum number of %s hosts"
+                        " allowed for your organization. Contact your System Administrator"
+                        " for assistance." % org.max_hosts
+                    )
+                )
+
+            # Don't check license if it is open license
+        if validation_info.get('license_type', 'UNLICENSED') == 'open':
+            return True
+
+        sys_free_instances = validation_info.get('free_instances', 0)
+        system_net_new_host_count = Host.objects.exclude(name__in=new_hosts).count()
+
+        if system_net_new_host_count > sys_free_instances:
+            hard_error = validation_info.get('trial', False) is True or validation_info['instance_count'] == 10
+            if hard_error:
+                # Only raise permission error for trial, otherwise just log a warning as we do in other inventory import situations
+                raise PermissionDenied(_("Host count exceeds available instances."))
+            logger.warning(_("Number of hosts allowed by license has been exceeded."))
+
+        return True
+
+    def validate(self, attrs):
+        request = self.context.get('request', None)
+        inv = attrs['inventory']
+        if request and not request.user.is_superuser:
+            if inv.organization:
+                org_admin_orgs = {tup[0] for tup in Organization.accessible_pk_qs(request.user, 'admin_role')}
+                inv_admin_orgs = {tup[0] for tup in Organization.accessible_pk_qs(request.user, 'inventory_admin_role')}
+                is_org_admin = inv.organization.id in org_admin_orgs
+                is_org_inv_admin = inv.organization.id in inv_admin_orgs
+            else:
+                is_org_admin = False
+                is_org_inv_admin = False
+            # This may not work, need to figure out what the role is called
+            is_inventory_admin = Inventory.accessible_pk_qs(request.user, 'inventory_admin_role').filter(id=inv.id).exists()
+            if not any([is_inventory_admin, is_org_admin, is_org_inv_admin]):
+                raise serializers.ValidationError(_(f'Inventory with id {inv.id} not found or lack permissions to add hosts.'))
+        current_hostnames = {h[0] for h in Host.objects.filter(inventory=inv).values_list('name').all()}
+        new_names = [host['name'] for host in attrs['hosts']]
+        duplicate_new_names = [n for n in new_names if n in current_hostnames or new_names.count(n) > 1]
+        if duplicate_new_names:
+            raise serializers.ValidationError(_(f'Hostnames must be unique in an inventory. Duplicates found: {duplicate_new_names}'))
+
+        self.raise_if_cannot_add_hosts(attrs)
+
+        _now = now()
+        for host in attrs['hosts']:
+            host['created'] = _now
+            host['modified'] = _now
+            host['inventory'] = inv
+        return attrs
+
+    def create(self, validated_data):
+        result = [Host(**attrs) for attrs in validated_data['hosts']]
+        try:
+            Host.objects.bulk_create(result)
+        except Exception as e:
+            raise serializers.ValidationError({"detail": _(f"{e}")})
+        return {"created": len(result), "url": InventorySerializer().get_related(validated_data['inventory'])['hosts']}
 
 
 class GroupTreeSerializer(GroupSerializer):

--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -1973,9 +1973,10 @@ class GroupSerializer(BaseSerializerWithVariables):
 
 
 class BulkHostSerializer(HostSerializer):
-    name = serializers.CharField(required=True, allow_blank=False, max_length=512)
+    name = serializers.CharField(required=False, allow_blank=False, max_length=512, help_text="Required for creation. Optional for deletion.")
     instance_id = serializers.CharField(required=False, max_length=1024)
     description = serializers.CharField(required=False)
+    id = serializers.IntegerField(required=False, min_value=1, help_text='Ignored on creation, only used for deletion. For delete, id supersedes "name"')
     enabled = serializers.BooleanField(default=True, required=False)
     variables = serializers.CharField(allow_blank=True, required=False)
 
@@ -1984,16 +1985,32 @@ class BulkHostSerializer(HostSerializer):
             'name',
             'enabled',
             'instance_id',
+            'id',
             'description',
             'variables',
         )
 
+    def validate(self, attrs):
+        delete = self.context.get('delete', False)
+        if not delete:
+            if not attrs.get('name'):
+                raise serializers.ValidationError(_(f'"name" required when creating hosts.'))
+            if attrs.get('id'):
+                # we ignore 'id' on POST
+                attrs.pop('id')
+        if delete:
+            if not (attrs.get('id') or attrs.get('name')):
+                raise serializers.ValidationError(_(f'Provide either "name" or "id" for host to be deleted.'))
+            if attrs.get('id') and attrs.get('name'):
+                attrs.pop('name')
+        return attrs
 
-class BulkHostCreateSerializer(serializers.Serializer):
+
+class BulkHostActionSerializer(serializers.Serializer):
     inventory = serializers.PrimaryKeyRelatedField(
         queryset=Inventory.objects.all(), required=True, write_only=True, help_text=_('Primary Key ID of inventory to add hosts to.')
     )
-    hosts = serializers.ListField(child=BulkHostSerializer(), allow_empty=False, max_length=1000, write_only=True, help_text=_('Hosts to be created.'))
+    hosts = serializers.ListField(child=BulkHostSerializer(), allow_empty=False, max_length=10000, write_only=True, help_text=_('Hosts to be created.'))
 
     class Meta:
         fields = ('inventory', 'hosts')
@@ -2033,7 +2050,7 @@ class BulkHostCreateSerializer(serializers.Serializer):
 
         return True
 
-    def validate(self, attrs):
+    def _validate_inventory_permissions(self, attrs):
         request = self.context.get('request', None)
         inv = attrs['inventory']
         if request and not request.user.is_superuser:
@@ -2049,6 +2066,13 @@ class BulkHostCreateSerializer(serializers.Serializer):
             is_inventory_admin = Inventory.accessible_pk_qs(request.user, 'inventory_admin_role').filter(id=inv.id).exists()
             if not any([is_inventory_admin, is_org_admin, is_org_inv_admin]):
                 raise serializers.ValidationError(_(f'Inventory with id {inv.id} not found or lack permissions to add hosts.'))
+        return attrs
+
+
+class BulkHostCreateSerializer(BulkHostActionSerializer):
+    def validate(self, attrs):
+        attrs = self._validate_inventory_permissions(attrs)
+        inv = attrs['inventory']
         current_hostnames = {h[0] for h in Host.objects.filter(inventory=inv).values_list('name').all()}
         new_names = [host['name'] for host in attrs['hosts']]
         duplicate_new_names = [n for n in new_names if n in current_hostnames or new_names.count(n) > 1]
@@ -2071,6 +2095,47 @@ class BulkHostCreateSerializer(serializers.Serializer):
         except Exception as e:
             raise serializers.ValidationError({"detail": _(f"{e}")})
         return {"created": len(result), "url": InventorySerializer().get_related(validated_data['inventory'])['hosts']}
+
+
+class BulkHostDeleteSerializer(BulkHostActionSerializer):
+    def validate(self, attrs):
+        attrs = self._validate_inventory_permissions(attrs)
+        inv = attrs['inventory']
+        hosts = attrs['hosts']
+        has_hostnames = [h['name'] for h in hosts if not h.get('id', None)]
+        has_id = [h['id'] for h in hosts if h.get('id', None)]
+        hosts_to_delete = None
+        if has_hostnames:
+            hosts_from_hostnames = Host.objects.filter(inventory=inv, name__in=has_hostname).all()
+            found = [found.name for found in hosts_from_hostsnames]
+            if len(has_hostnames) != len(found):
+                missing = [h for h in has_hostnames if h not in found]
+                raise serializers.ValidationError(_(f'Host(s) not found for inventory {inv.id}. Errors: {missing}'))
+            hosts_to_delete = hosts_from_hostnames
+
+        if has_id:
+            hosts_from_id = Host.objects.filter(inventory=inv, id__in=has_id).all()
+            found = [found.id for found in hosts_from_id]
+            if len(has_id) != len(found):
+                missing = [h for h in has_id if h not in found]
+                raise serializers.ValidationError(_(f'Host(s) not found for inventory {inv.id}. Errors: {missing}'))
+            if hosts_to_delete:
+                hosts_to_delete.union(hosts_from_id)
+            else:
+                hosts_to_delete = hosts_from_id
+
+        attrs['hosts'] = hosts_to_delete
+        return attrs
+
+    def create(self, validated_data):
+        """This is actually a delete method...implemented with POST and 'create' so we can take data in."""
+        hosts = validated_data['hosts']
+        num_hosts = len(hosts)
+        try:
+            hosts.delete()
+        except Exception as e:
+            raise serializers.ValidationError({"detail": _(f"{e}")})
+        return {"deleted": num_hosts, "url": InventorySerializer().get_related(validated_data['inventory'])['hosts']}
 
 
 class GroupTreeSerializer(GroupSerializer):

--- a/awx/api/templates/api/bulk_host_create_view.md
+++ b/awx/api/templates/api/bulk_host_create_view.md
@@ -1,0 +1,16 @@
+# Bulk Host Create
+
+This endpoint allows the client to create multiple hosts and associate them with an inventory. They may do this by providing the inventory ID and a list of json that would normally be provided to create hosts.
+
+Example:
+
+```
+{
+"inventory": 1,
+"hosts": [
+    {"name": "example1.com"},
+    {"name": "example2.com"}
+]
+
+}
+```

--- a/awx/api/templates/api/bulk_view.md
+++ b/awx/api/templates/api/bulk_view.md
@@ -1,0 +1,3 @@
+# Bulk Actions
+
+This endpoint lists available bulk action APIs. 

--- a/awx/api/urls/urls.py
+++ b/awx/api/urls/urls.py
@@ -31,6 +31,10 @@ from awx.api.views import (
     ApplicationOAuth2TokenList,
     OAuth2ApplicationDetail,
 )
+from awx.api.views.bulk import (
+    BulkView,
+    BulkHostCreateView,
+)
 from awx.api.views.mesh_visualizer import MeshVisualizer
 
 from awx.api.views.metrics import MetricsView
@@ -136,6 +140,8 @@ v2_urls = [
     re_path(r'^activity_stream/', include(activity_stream_urls)),
     re_path(r'^workflow_approval_templates/', include(workflow_approval_template_urls)),
     re_path(r'^workflow_approvals/', include(workflow_approval_urls)),
+    re_path(r'^bulk/host_create/$', BulkHostCreateView.as_view(), name='bulk_host_create'),
+    re_path(r'^bulk/$', BulkView.as_view(), name='bulk'),
 ]
 
 

--- a/awx/api/urls/urls.py
+++ b/awx/api/urls/urls.py
@@ -34,6 +34,7 @@ from awx.api.views import (
 from awx.api.views.bulk import (
     BulkView,
     BulkHostCreateView,
+    BulkHostDeleteView,
 )
 from awx.api.views.mesh_visualizer import MeshVisualizer
 
@@ -141,6 +142,7 @@ v2_urls = [
     re_path(r'^workflow_approval_templates/', include(workflow_approval_template_urls)),
     re_path(r'^workflow_approvals/', include(workflow_approval_urls)),
     re_path(r'^bulk/host_create/$', BulkHostCreateView.as_view(), name='bulk_host_create'),
+    re_path(r'^bulk/host_delete/$', BulkHostDeleteView.as_view(), name='bulk_host_delete'),
     re_path(r'^bulk/$', BulkView.as_view(), name='bulk'),
 ]
 

--- a/awx/api/views/bulk.py
+++ b/awx/api/views/bulk.py
@@ -1,0 +1,49 @@
+from collections import OrderedDict
+
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.renderers import JSONRenderer
+from rest_framework.reverse import reverse
+from rest_framework import status
+from rest_framework.response import Response
+
+from awx.api.generics import (
+    GenericAPIView,
+    APIView,
+)
+from awx.api import (
+    serializers,
+    renderers,
+)
+
+
+class BulkView(APIView):
+    _ignore_model_permissions = True
+    permission_classes = [IsAuthenticated]
+    renderer_classes = [
+        renderers.BrowsableAPIRenderer,
+        JSONRenderer,
+    ]
+    allowed_methods = ['GET', 'OPTIONS']
+
+    def get(self, request, format=None):
+        '''List top level resources'''
+        data = OrderedDict()
+        data['bulk_host_create'] = reverse('api:bulk_host_create', request=request)
+        return Response(data)
+
+
+class BulkHostCreateView(GenericAPIView):
+    _ignore_model_permissions = True
+    permission_classes = [IsAuthenticated]
+    serializer_class = serializers.BulkHostCreateSerializer
+    allowed_methods = ['GET', 'POST', 'OPTIONS']
+
+    def get(self, request):
+        return Response({"detail": "Bulk create hosts with this endpoint"}, status=status.HTTP_200_OK)
+
+    def post(self, request):
+        serializer = serializers.BulkHostCreateSerializer(data=request.data, context={'request': request})
+        if serializer.is_valid():
+            result = serializer.create(serializer.validated_data)
+            return Response(result, status=status.HTTP_201_CREATED)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/awx/api/views/bulk.py
+++ b/awx/api/views/bulk.py
@@ -29,6 +29,7 @@ class BulkView(APIView):
         '''List top level resources'''
         data = OrderedDict()
         data['bulk_host_create'] = reverse('api:bulk_host_create', request=request)
+        data['bulk_host_delete'] = reverse('api:bulk_host_delete', request=request)
         return Response(data)
 
 
@@ -46,4 +47,21 @@ class BulkHostCreateView(GenericAPIView):
         if serializer.is_valid():
             result = serializer.create(serializer.validated_data)
             return Response(result, status=status.HTTP_201_CREATED)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+
+class BulkHostDeleteView(GenericAPIView):
+    _ignore_model_permissions = True
+    permission_classes = [IsAuthenticated]
+    serializer_class = serializers.BulkHostDeleteSerializer
+    allowed_methods = ['GET', 'POST', 'OPTIONS']
+
+    def get(self, request):
+        return Response({"detail": "Bulk delete hosts with this endpoint"}, status=status.HTTP_200_OK)
+
+    def post(self, request):
+        serializer = serializers.BulkHostDeleteSerializer(data=request.data, context={'request': request, 'delete': True})
+        if serializer.is_valid():
+            result = serializer.create(serializer.validated_data)
+            return Response(result, status=status.HTTP_200_OK)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/awx/api/views/root.py
+++ b/awx/api/views/root.py
@@ -124,6 +124,7 @@ class ApiVersionRootView(APIView):
         data['workflow_job_template_nodes'] = reverse('api:workflow_job_template_node_list', request=request)
         data['workflow_job_nodes'] = reverse('api:workflow_job_node_list', request=request)
         data['mesh_visualizer'] = reverse('api:mesh_visualizer_view', request=request)
+        data['bulk'] = reverse('api:bulk', request=request)
         return Response(data)
 
 


### PR DESCRIPTION
This feels hacky because I'm using POST/create method but that seemed the way to go since I want to accept a payload.

This results in approximately 2 queries per item deleted -- but it is still pretty fast. As a test I removed the 1000 host limit previously placed on host create and tested with an inventory with approximately 40k hosts. It took approx 6 seconds and ~ 80k queries (see detail below)

I think if we want to get faster we need to think about raw sql and what things need to get cascade deleted or otherwise figuring out how to override default delete() behavior.

HTTP 200 OK
Allow: GET, POST, OPTIONS
Content-Type: application/json
Vary: Accept
X-API-Node: awx_1
X-API-Product-Name: AWX
X-API-Product-Version: 21.6.1.dev146+g1619462fb0
X-API-Query-Count: 8083
X-API-Query-Time: 0.175s
X-API-Time: 6.183s

{
    "deleted": 3965,
    "url": "/api/v2/inventories/1/hosts/"
}

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Breaking Change 
 - New or Enhanced Feature
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 - UI
 - Collection
 - CLI
 - Docs
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
